### PR TITLE
fix(help_OLAP): comment out fact and dimension tables elimination code

### DIFF
--- a/olap/help_OLAP.sql
+++ b/olap/help_OLAP.sql
@@ -1,5 +1,8 @@
 USE Festival_Final_OLAP;
 GO
+-- This block is used to reset the database schema by dropping all fact and dimension tables.
+-- It is currently disabled to prevent accidental execution. Re-enable this block only during
+-- development or testing when a full schema reset is required.
 /*
 -- Primero eliminamos las tablas de hechos (que referencian a otras tablas)
 PRINT 'Eliminando tablas de hechos...';

--- a/olap/help_OLAP.sql
+++ b/olap/help_OLAP.sql
@@ -1,6 +1,6 @@
 USE Festival_Final_OLAP;
 GO
-
+/*
 -- Primero eliminamos las tablas de hechos (que referencian a otras tablas)
 PRINT 'Eliminando tablas de hechos...';
 
@@ -84,7 +84,7 @@ IF OBJECT_ID('DIM_Tiempo', 'U') IS NOT NULL
 
 PRINT 'Todas las tablas han sido eliminadas con éxito.';
 GO
-
+*/
 
 PRINT '===== VERIFICACIÓN DE TABLAS DE DIMENSIONES =====';
 


### PR DESCRIPTION
This pull request includes minor updates to the `olap/help_OLAP.sql` file. The changes primarily involve commenting out sections of code related to the deletion of fact  and dimension tables and the confirmation of table deletions.

* [`olap/help_OLAP.sql`](diffhunk://#diff-ccdad7994c650201400874b189bf26a64aaf00700f0f3291cbc1d22171db4465L3-R3): Commented out the code block responsible for removing fact and dimension tables and printing a success message after deletion. This indicates a temporary decision to disable these operations. [[1]](diffhunk://#diff-ccdad7994c650201400874b189bf26a64aaf00700f0f3291cbc1d22171db4465L3-R3) [[2]](diffhunk://#diff-ccdad7994c650201400874b189bf26a64aaf00700f0f3291cbc1d22171db4465L87-R87)

* Closes #8 